### PR TITLE
Add suggested changes from review of PR 190

### DIFF
--- a/packages/jupyter-chat/src/__tests__/mocks.ts
+++ b/packages/jupyter-chat/src/__tests__/mocks.ts
@@ -1,0 +1,26 @@
+import {
+  AbstractChatContext,
+  AbstractChatModel,
+  IChatModel,
+  IChatContext
+} from '../model';
+import { INewMessage } from '../types';
+
+export class MockChatContext
+  extends AbstractChatContext
+  implements IChatContext
+{
+  get users() {
+    return [];
+  }
+}
+
+export class MockChatModel extends AbstractChatModel implements IChatModel {
+  sendMessage(message: INewMessage): Promise<boolean | void> | boolean | void {
+    // No-op
+  }
+
+  createChatContext(): IChatContext {
+    return new MockChatContext({ model: this });
+  }
+}

--- a/packages/jupyter-chat/src/__tests__/model.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/model.spec.ts
@@ -7,31 +7,26 @@
  * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
  */
 
-import { AbstractChatModel, IChatModel } from '../model';
+import { AbstractChatModel, IChatContext, IChatModel } from '../model';
 import { IChatMessage, INewMessage } from '../types';
-
-class MyChatModel extends AbstractChatModel {
-  sendMessage(message: INewMessage): Promise<boolean | void> | boolean | void {
-    // No-op
-  }
-}
+import { MockChatModel, MockChatContext } from './mocks';
 
 describe('test chat model', () => {
   describe('model instantiation', () => {
     it('should create an AbstractChatModel', () => {
-      const model = new MyChatModel();
+      const model = new MockChatModel();
       expect(model).toBeInstanceOf(AbstractChatModel);
     });
 
     it('should dispose an AbstractChatModel', () => {
-      const model = new MyChatModel();
+      const model = new MockChatModel();
       model.dispose();
       expect(model.isDisposed).toBeTruthy();
     });
   });
 
   describe('incoming message', () => {
-    class TestChat extends AbstractChatModel {
+    class TestChat extends AbstractChatModel implements IChatModel {
       protected formatChatMessage(message: IChatMessage): IChatMessage {
         message.body = 'formatted msg';
         return message;
@@ -40,6 +35,10 @@ describe('test chat model', () => {
         message: INewMessage
       ): Promise<boolean | void> | boolean | void {
         // No-op
+      }
+
+      createChatContext(): IChatContext {
+        return new MockChatContext({ model: this });
       }
     }
 
@@ -58,7 +57,7 @@ describe('test chat model', () => {
     });
 
     it('should signal incoming message', () => {
-      model = new MyChatModel();
+      model = new MockChatModel();
       model.messagesUpdated.connect((sender: IChatModel) => {
         expect(sender).toBe(model);
         messages = model.messages;
@@ -83,12 +82,12 @@ describe('test chat model', () => {
 
   describe('model config', () => {
     it('should have empty config', () => {
-      const model = new MyChatModel();
+      const model = new MockChatModel();
       expect(model.config.sendWithShiftEnter).toBeUndefined();
     });
 
     it('should allow config', () => {
-      const model = new MyChatModel({ config: { sendWithShiftEnter: true } });
+      const model = new MockChatModel({ config: { sendWithShiftEnter: true } });
       expect(model.config.sendWithShiftEnter).toBeTruthy();
     });
   });

--- a/packages/jupyter-chat/src/__tests__/widgets.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/widgets.spec.ts
@@ -11,22 +11,16 @@ import {
   IRenderMimeRegistry,
   RenderMimeRegistry
 } from '@jupyterlab/rendermime';
-import { AbstractChatModel, IChatModel } from '../model';
-import { INewMessage } from '../types';
+import { IChatModel } from '../model';
 import { ChatWidget } from '../widgets/chat-widget';
-
-class MyChatModel extends AbstractChatModel {
-  sendMessage(message: INewMessage): Promise<boolean | void> | boolean | void {
-    // No-op
-  }
-}
+import { MockChatModel } from './mocks';
 
 describe('test chat widget', () => {
   let model: IChatModel;
   let rmRegistry: IRenderMimeRegistry;
 
   beforeEach(() => {
-    model = new MyChatModel();
+    model = new MockChatModel();
     rmRegistry = new RenderMimeRegistry();
   });
 

--- a/packages/jupyter-chat/src/chat-commands/types.ts
+++ b/packages/jupyter-chat/src/chat-commands/types.ts
@@ -22,7 +22,7 @@ export type ChatCommand = {
    * If set, this will be rendered as the icon for the command in the chat
    * commands menu. Jupyter Chat will choose a default if this is unset.
    */
-  icon?: LabIcon | JSX.Element | string;
+  icon?: LabIcon | JSX.Element | string | null;
 
   /**
    * If set, this will be rendered as the description for the command in the

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -553,9 +553,7 @@ export abstract class AbstractChatModel implements IChatModel {
   /**
    * Create the chat context that will be passed to the input model.
    */
-  createChatContext(): IChatContext {
-    return new ChatContext({ model: this });
-  }
+  abstract createChatContext(): IChatContext;
 
   /**
    * Add unread messages to the list.
@@ -681,13 +679,17 @@ export interface IChatContext {
    * A copy of the messages.
    */
   readonly messages: IChatMessage[];
+  /**
+   * A list of all users who have connected to this chat.
+   */
+  readonly users: IUser[];
 }
 
 /**
- * A default implementation of the IChatContext, that can be extended to provide more
- * attributes.
+ * An abstract base class implementing `IChatContext`. This can be extended into
+ * a complete implementation, as done in `jupyterlab-chat`.
  */
-export class ChatContext implements IChatContext {
+export abstract class AbstractChatContext implements IChatContext {
   constructor(options: { model: IChatModel }) {
     this._model = options.model;
   }
@@ -699,6 +701,11 @@ export class ChatContext implements IChatContext {
   get messages(): IChatMessage[] {
     return [...this._model.messages];
   }
+
+  /**
+   * ABSTRACT: Should return a list of users who have connected to this chat.
+   */
+  abstract get users(): IUser[];
 
   protected _model: IChatModel;
 }

--- a/packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx
+++ b/packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx
@@ -3,6 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import React from 'react';
 import {
   IChatCommandProvider,
   IChatCommandRegistry,
@@ -12,8 +13,6 @@ import {
   IUser
 } from '@jupyter/chat';
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { User } from '@jupyterlab/services';
-import { LabChatContext } from 'jupyterlab-chat';
 
 export const mentionCommandsPlugin: JupyterFrontEndPlugin<void> = {
   id: 'jupyterlab-chat-extension:mentionCommandsPlugin',
@@ -38,7 +37,7 @@ class MentionCommandProvider implements IChatCommandProvider {
       return [];
     }
 
-    const users = (inputModel.chatContext as LabChatContext).users;
+    const users = inputModel.chatContext.users;
     users.forEach(user => {
       let mentionName = user.mention_name;
       if (!mentionName) {
@@ -48,7 +47,7 @@ class MentionCommandProvider implements IChatCommandProvider {
 
       this._users.set(mentionName, {
         user,
-        icon: Avatar({ user: user as User.IIdentity }) ?? undefined
+        icon: <Avatar user={user} />
       });
     });
 
@@ -82,7 +81,7 @@ class MentionCommandProvider implements IChatCommandProvider {
 namespace Private {
   export type CommandUser = {
     user: IUser;
-    icon?: JSX.Element;
+    icon: JSX.Element | null;
   };
 
   /**

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -440,14 +440,9 @@ export class LabChatContext extends ChatContext {
     const model = this._model as LabChatModel;
     const users = new Set<IUser>();
 
-    // Get the user list from the chat file.
+    // Get the user list from the shared YChat
     Object.values(model.sharedModel.users).forEach(userObject => {
-      userObject = userObject as JSONObject;
-      if (!userObject.username) {
-        return;
-      }
-
-      users.add(userObject as unknown as IUser);
+      users.add(userObject);
     });
 
     // Add the users connected to the chat (even if they never sent a message).
@@ -458,6 +453,7 @@ export class LabChatContext extends ChatContext {
       }
       users.add(user);
     });
+
     return Array.from(users);
   }
 }

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -5,7 +5,7 @@
 
 import {
   AbstractChatModel,
-  ChatContext,
+  AbstractChatContext,
   IAttachment,
   IChatContext,
   IChatMessage,
@@ -17,12 +17,7 @@ import {
 import { IChangedArgs } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { User } from '@jupyterlab/services';
-import {
-  JSONObject,
-  PartialJSONObject,
-  PromiseDelegate,
-  UUID
-} from '@lumino/coreutils';
+import { PartialJSONObject, PromiseDelegate, UUID } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 
 import { IWidgetConfig } from './token';
@@ -431,10 +426,9 @@ export class LabChatModel
 /**
  * The chat context to be sent to the input model.
  */
-export class LabChatContext extends ChatContext {
+export class LabChatContext extends AbstractChatContext {
   /**
-   * The list of users who already wrote or has been mentioned in the chat, or are
-   * currently connected to it.
+   * The list of users who have connected to this chat.
    */
   get users(): IUser[] {
     const model = this._model as LabChatModel;

--- a/packages/jupyterlab-chat/src/ychat.ts
+++ b/packages/jupyterlab-chat/src/ychat.ts
@@ -100,8 +100,13 @@ export class YChat extends YDocument<IChatChanges> {
     return (this._metadata.get('id') as string) || '';
   }
 
-  get users(): JSONObject {
-    return JSONExt.deepCopy(this._users.toJSON());
+  get users(): Record<string, IUser> {
+    const userDict = JSONExt.deepCopy(this._users.toJSON()) as Record<
+      string,
+      IUser
+    >;
+
+    return userDict;
   }
 
   get messages(): string[] {


### PR DESCRIPTION
## Description

- Removes type casts from `LabChatContext` and `MentionCommandProvider`.
- Adds the `users` property to `IChatContext` to remove the need for type-casting.
- Makes `ChatContext` abstract and renames it to `AbstractChatContext`. The `users` property is left abstract.
- Fixes the unit tests and moves mock classes (`MockChatModel`, `MockChatContext`) into a separate file, `mocks.ts`.